### PR TITLE
ci: add github superlinter workflow

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,50 @@
+---
+#################################
+#################################
+## Super Linter GitHub Actions ##
+#################################
+#################################
+name: Lint Code Base
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+    branches-ignore: [master, main]
+    # Remove the line above to run when pushing to master
+  pull_request:
+    branches: [master, main]
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: Lint Code Base
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          # Full git history is needed to get a proper
+          # list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Readme.md
+++ b/Readme.md
@@ -85,3 +85,9 @@ All parameters are configured in control_plane/config/p4-upf.yaml  (the config f
 ## Funding
 
 This project was funded by Deutsche Telekom Technik GmbH as part of the project Dynamic Networks.
+
+## Code Style
+
+This repository uses the
+[GitHub Super-Linter](https://github.com/github/super-linter#super-linter) to
+check and enforce code style following community standards.


### PR DESCRIPTION
* add superlinter as default workflow following the documentation here: https://github.com/github/super-linter#how-to-use
* run ci with default value for VALIDATE_ALL_CODEBASE (true), since already existing code has not been linted so far

Signed-off-by: Jan Klare <jan.klare@bisdn.de>